### PR TITLE
fix: adds patch as new default semver

### DIFF
--- a/bash/src/changelog_release.bash
+++ b/bash/src/changelog_release.bash
@@ -22,7 +22,7 @@ set -o errtrace
 INPUT_GIT_BRANCH_NAME="none"
 INPUT_IS_INTERACTIVE=""
 INPUT_PROJECT_TYPE=""
-INPUT_SEMVER_SCOPE="minor"
+INPUT_SEMVER_SCOPE="patch"
 INPUT_REPOURL=''
 INPUT_TAG=""
 
@@ -257,7 +257,7 @@ usage() {
     "" \
     " -h --help            Print this help and exit" \
     " -d --debug           Output extra script run information" \
-    " -s --semver-scope    Semver scope for next tag when autoidentify <major|minor|patch>. Default: minor" \
+    " -s --semver-scope    Semver scope for next tag when autoidentify <major|minor|patch>. Default: patch" \
     " -t --next-tag        Specify next tag instead of autoidentify" \
     " -p --project-type    Which project type <npm|mvn|gradle|none>. Default: try autoidentify by existing file." \
     " -b --git-branch-name Git branch name to push to (any_name). 'none' skips push. Default: none. " \

--- a/bash/src/test/changelog_release_integration_test.bats
+++ b/bash/src/test/changelog_release_integration_test.bats
@@ -171,7 +171,7 @@ function assert_scriptrun_output() {
   # all setup, now run it
   cd "${TEST_TEMP_DIR}/${project_name}" || exit 1
   git remote add origin ../integtest.git
-  run ./changelog_release.bash --git-branch-name "${branch_name}"
+  run ./changelog_release.bash --semver-scope 'minor' --git-branch-name "${branch_name}"
 
   assert_output --partial "Calculating next tag from semver scope: ${YELLOW}minor${NC}"
   assert_output --partial "Calculated tag version: ${YELLOW}1.1.0${NC}"

--- a/bash/src/test/changelog_release_unit_test.bats
+++ b/bash/src/test/changelog_release_unit_test.bats
@@ -117,7 +117,7 @@ function calculate_next_version_gets_latest_tag_if_no_tags_given() { #@test
   }
 
   calculate_next_version
-  assert_equal "$NEXT_TAG" "in_semver bump minor git_tag"
+  assert_equal "$NEXT_TAG" "in_semver bump patch git_tag"
 
 }
 
@@ -134,7 +134,7 @@ function calculate_next_version_sets_default_test_if_no_tags_found() { #@test
     echo "in_semver $@"
   }
   calculate_next_version
-  assert_equal "$NEXT_TAG" "in_semver bump minor 0.0.0"
+  assert_equal "$NEXT_TAG" "in_semver bump patch 0.0.0"
 
 }
 


### PR DESCRIPTION
Fixes: Defaulting semver should be patch #19 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

The changes have been tested by running the script using no flag thereby using the new default and checking the resulting increase in patch semver
